### PR TITLE
#9 Supply separate secret names for harbor's two ingress certs

### DIFF
--- a/templates/harbor.yaml
+++ b/templates/harbor.yaml
@@ -27,6 +27,9 @@ spec:
         annotations:
           kubernetes.io/ingress.class: nginx
           cert-manager.io/cluster-issuer: letsencrypt
+      tls:
+        notarySecretName: tls-harbor-notary-ingress
+        secretName: tls-harbor-ingress
     externalURL: https://harbor.{{ .Values.hostedZone }}
     persistence:
     {{- with .Values.harbor.persistence.imageChartStorage}}
@@ -59,7 +62,7 @@ spec:
     repository: https://dandydeveloper.github.io/charts
     name: redis-ha
     version: 4.5.3
-  values: 
+  values:
     haproxy:
       enabled: true
 


### PR DESCRIPTION
Connects to #9 

This change allows both certs to issue successfully in my test cluster