### PR TITLE
#11 Grafana backend: fix the service address for Loki

### DIFF
--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -67,7 +67,7 @@ spec:
         - name: loki
           type: loki
           access: proxy
-          url: http://loki.{{ .Values.lokiStack.namespace }}.svc:3100
+          url: http://{{ .Values.lokiStack.releaseName }}.{{ .Values.lokiStack.namespace }}.svc:3100
           jsonData:
             maxLines: 1000
 


### PR DESCRIPTION
Connects to #11 

Based on what I could tell from the loki-stack chart source, the default name for the service is the release name. In my test cluster I was able to run log queries after making this change and re-installing.