### PR TITLE
Use the latest version of the navigator chart

### DIFF
--- a/templates/navigator.yaml
+++ b/templates/navigator.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     repository: https://revelrylabs.github.io/helm-charts
     name: moondog-navigator
-    version: 0.0.4
+    version: 0.0.6
   values:
     appDomain: navigator.{{ .Values.hostedZone }}
     {{- with .Values.navigator.image }}


### PR DESCRIPTION
Ran into a couple of issues on a fresh installation that were resolved by the 0.0.6 version