### PR TITLE
Bring DB backup config into the Harbor config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -173,6 +173,9 @@ Configures the [`harbor`](https://github.com/goharbor/harbor-helm) chart.
 | `harbor.postgres.user` |  |  |
 | `harbor.postgres.password` |  |  |
 | `harbor.persistence.imageChartStorage` |  |  |
+| `harbor.dbBackups.bucketName` | string (optional) | Name of an S3 bucket to use for database backups. |
+| `harbor.dbBackups.credentials.accessKeyId` | string (optional) | Id of the AWS Access Key to access the S3 bucket for backups. |
+| `harbor.dbBackups.credentials.secretAccessKey` | string (optional) | AWS Secret Access Key to access the S3 bucket for backups. |
 
 ## kubedb
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -173,6 +173,7 @@ Configures the [`harbor`](https://github.com/goharbor/harbor-helm) chart.
 | `harbor.postgres.user` |  |  |
 | `harbor.postgres.password` |  |  |
 | `harbor.persistence.imageChartStorage` |  |  |
+| `harbor.dbBackups.enabled` | boolean (optional; default `true`) | Whether to enable DB backups. `true` requires the other backup options also. |
 | `harbor.dbBackups.bucketName` | string (optional) | Name of an S3 bucket to use for database backups. |
 | `harbor.dbBackups.credentials.accessKeyId` | string (optional) | Id of the AWS Access Key to access the S3 bucket for backups. |
 | `harbor.dbBackups.credentials.secretAccessKey` | string (optional) | AWS Secret Access Key to access the S3 bucket for backups. |

--- a/templates/harbor-kubedb.yaml
+++ b/templates/harbor-kubedb.yaml
@@ -1,9 +1,6 @@
 {{- if and .Values.harbor.create .Values.kubedb.create }}
 
-{{- $backupsEnabled := false }}
-{{- with .Values.harbor.dbBackups }}
-  {{ $backupsEnabled = and .bucketName .credentials.accessKeyId .credentials.secretAccessKey }}
-{{- end }}
+{{- $backupsEnabled := .Values.harbor.dbBackups.enabled }}
 
 apiVersion: v1
 kind: Namespace

--- a/templates/harbor-kubedb.yaml
+++ b/templates/harbor-kubedb.yaml
@@ -1,5 +1,10 @@
 {{- if and .Values.harbor.create .Values.kubedb.create }}
 
+{{- $backupsEnabled := false }}
+{{- with .Values.harbor.dbBackups }}
+  {{ $backupsEnabled = and .bucketName .credentials.accessKeyId .credentials.secretAccessKey }}
+{{- end }}
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -17,7 +22,7 @@ spec:
   standbyMode: Hot
   streamingMode: asynchronous
   storageType: "Durable"
-  databaseSecret: 
+  databaseSecret:
     secretName: harbor-db-auth
   storage:
     storageClassName: aws-ebs-gp2
@@ -30,12 +35,13 @@ spec:
     scriptSource:
       configMap:
         name: harbor-init-sql
+  {{- if $backupsEnabled }}
   backupSchedule:
     cronExpression: "@every 30m"
     storageSecretName: s3-credentials
     s3:
       endpoint: "s3.amazonaws.com"
-      bucket: {{ .Values.kubedb.aws.s3_bucket }}
+      bucket: {{ .Values.harbor.dbBackups.bucketName | quote }}
       prefix: harbor-pg
     podTemplate:
       spec:
@@ -46,6 +52,7 @@ spec:
           limits:
             cpu: 500m
             memory: 1G
+  {{- end }}
   podTemplate:
     spec:
       resources:
@@ -70,6 +77,7 @@ data:
   POSTGRES_PASSWORD: {{ .Values.harbor.postgres.password | b64enc | quote }}
   POSTGRES_USER: {{ .Values.harbor.postgres.user | b64enc | quote }}
 
+{{- if $backupsEnabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -78,8 +86,11 @@ metadata:
   namespace: {{ .Values.harbor.namespace }}
 type: Opaque
 data:
-  AWS_ACCESS_KEY_ID: {{ .Values.kubedb.aws.access_key | b64enc | quote }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.kubedb.aws.access_key_secret | b64enc | quote }}
+  {{- with .Values.harbor.dbBackups.credentials }}
+  AWS_ACCESS_KEY_ID: {{ .accessKeyId | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .secretAccessKey | b64enc | quote }}
+  {{- end }}
+{{- end }}
 
 ---
 apiVersion: v1

--- a/values.yaml
+++ b/values.yaml
@@ -147,6 +147,11 @@ harbor:
   namespace: md-harbor
   postgres:
     user: md_harbor
+  dbBackups: {}
+    # bucketName: S3_BUCKET_NAME
+    # credentials:
+    #   accessKeyId: AWS_ACCESS_KEY_ID
+    #   secretAccessKey: AWS_SECRET_ACCESS_KEY
   persistence:
     imageChartStorage: {}
 #  we use S3 but this can be defined as any type you like per the harbor chart here:

--- a/values.yaml
+++ b/values.yaml
@@ -147,7 +147,8 @@ harbor:
   namespace: md-harbor
   postgres:
     user: md_harbor
-  dbBackups: {}
+  dbBackups:
+    enabled: true
     # bucketName: S3_BUCKET_NAME
     # credentials:
     #   accessKeyId: AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Connects to #17 

- Move the configuration for the KubeDB backup into the harbor section where it's used
- This also means each app can have its own backup config (if future apps use KubeDB)
- And make DB backup optional if you're experimenting or don't want to use AWS