### PR TITLE
Add multiple ClusterIssuers no matter what, but only use 1 for MDE ingresses

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,7 @@ Configures the [`cert-manager`](https://hub.helm.sh/charts/jetstack/cert-manager
 | `certManager.releaseName` | string (optional) | The release name for the HelmRelease |
 | `certManager.replicaCount` | integer (optional; default `1`) | The number of replicas for the deployment |
 | `certManager.email` | string | The support email address reported to LetsEncrypt |
+| `certManager.defaultClusterIssuer` | string (optional; default `"letsencrypt"`) | Can be switched to `"letsencrypt-staging"` for testing to use LetsEncrypt's [staging environment](https://letsencrypt.org/docs/staging-environment/) |
 
 ## dex
 

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -20,15 +20,6 @@ spec:
   values:
     replicaCount: {{ .Values.certManager.replicaCount }}
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ca-issuer-keypair
-  namespace: {{ .Values.certManager.namespace }}
-data:
-  tls.crt: {{ .Values.ca.crt | b64enc | quote }}
-  tls.key: {{ .Values.ca.key | b64enc | quote }}
----
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
@@ -60,14 +51,5 @@ spec:
       - http01:
           ingress:
             class: nginx
----
-apiVersion: cert-manager.io/v1alpha2
-kind: ClusterIssuer
-metadata:
-  name: ca-issuer
-  namespace: {{ .Values.certManager.namespace }}
-spec:
-  ca:
-    secretName: ca-issuer-keypair
 
 {{- end }}

--- a/templates/cert-manager.yaml
+++ b/templates/cert-manager.yaml
@@ -19,17 +19,15 @@ spec:
     version: v0.13.0
   values:
     replicaCount: {{ .Values.certManager.replicaCount }}
-{{- if .Values.certManager.fake}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ca-cert-key
+  name: ca-issuer-keypair
   namespace: {{ .Values.certManager.namespace }}
 data:
   tls.crt: {{ .Values.ca.crt | b64enc | quote }}
   tls.key: {{ .Values.ca.key | b64enc | quote }}
-{{- end}}
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
@@ -37,12 +35,8 @@ metadata:
   name: letsencrypt
   namespace: {{ .Values.certManager.namespace }}
 spec:
-  {{- if .Values.certManager.fake}}
-  ca:
-    secretName: ca-cert-key
-  {{- else}}
   acme:
-    server: https://acme-v02.api.letsencrypt.org/directory 
+    server: https://acme-v02.api.letsencrypt.org/directory
     email: {{ .Values.certManager.email | quote }}
     privateKeySecretRef:
       name: letsencrypt
@@ -50,6 +44,30 @@ spec:
       - http01:
           ingress:
             class: nginx
-  {{- end }}
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  namespace: {{ .Values.certManager.namespace }}
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: {{ .Values.certManager.email | quote }}
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: ca-issuer
+  namespace: {{ .Values.certManager.namespace }}
+spec:
+  ca:
+    secretName: ca-issuer-keypair
 
 {{- end }}

--- a/templates/dex.yaml
+++ b/templates/dex.yaml
@@ -85,7 +85,7 @@ spec:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
-        cert-manager.io/cluster-issuer: letsencrypt
+        cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
       hosts:
         - dex.{{ .Values.hostedZone }}
       tls:

--- a/templates/gangway.yaml
+++ b/templates/gangway.yaml
@@ -55,7 +55,7 @@ spec:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
-        cert-manager.io/cluster-issuer: letsencrypt
+        cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
       hosts:
         - gangway.{{ .Values.hostedZone }}
       tls:

--- a/templates/harbor.yaml
+++ b/templates/harbor.yaml
@@ -26,7 +26,7 @@ spec:
           notary: harbor-notary.{{ .Values.hostedZone }}
         annotations:
           kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: letsencrypt
+          cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
       tls:
         notarySecretName: tls-harbor-notary-ingress
         secretName: tls-harbor-ingress

--- a/templates/navigator.yaml
+++ b/templates/navigator.yaml
@@ -42,7 +42,7 @@ spec:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: nginx
-        cert-manager.io/cluster-issuer: letsencrypt
+        cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
       hosts:
         - host: navigator.{{ .Values.hostedZone }}
           paths: ["/"]

--- a/templates/oauth2-proxy.yaml
+++ b/templates/oauth2-proxy.yaml
@@ -34,7 +34,7 @@ spec:
         - oauth2-proxy.{{ .Values.hostedZone }}
       annotations:
         kubernetes.io/ingress.class: nginx
-        cert-manager.io/cluster-issuer: letsencrypt
+        cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
       tls:
         - secretName: oauth2-proxy-tls
           hosts:

--- a/templates/prometheus-operator.yaml
+++ b/templates/prometheus-operator.yaml
@@ -52,7 +52,7 @@ spec:
         enabled: true
         annotations:
           kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: letsencrypt
+          cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
         hosts:
           - grafana.{{ .Values.hostedZone }}
         path: /
@@ -76,7 +76,7 @@ spec:
         enabled: true
         annotations:
           kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: letsencrypt
+          cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
           nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.{{ .Values.hostedZone }}/oauth2/auth"
           nginx.ingress.kubernetes.io/auth-signin: "https://oauth2-proxy.{{ .Values.hostedZone }}/oauth2/start?rd=$scheme://$best_http_host$request_uri"
         hosts:
@@ -108,7 +108,7 @@ spec:
         enabled: true
         annotations:
           kubernetes.io/ingress.class: nginx
-          cert-manager.io/cluster-issuer: letsencrypt
+          cert-manager.io/cluster-issuer: {{ .Values.certManager.defaultClusterIssuer | quote }}
           nginx.ingress.kubernetes.io/auth-url: "https://oauth2-proxy.{{ .Values.hostedZone }}/oauth2/auth"
           nginx.ingress.kubernetes.io/auth-signin: "https://oauth2-proxy.{{ .Values.hostedZone }}/oauth2/start?rd=$scheme://$best_http_host$request_uri"
         hosts:

--- a/values.yaml
+++ b/values.yaml
@@ -111,6 +111,11 @@ certManager:
   releaseName: md-cert-manager
   namespace: md-cert-manager
   # email: me@example.com
+  # The chart provides 3 ClusterIssuers:
+  #   * "letsencrypt" provisions production certs; this is the right choice for production deployment
+  #   * "letsencrypt-staging" uses LetsEncrypt's staging server, which is good for testing and has generous rate limits
+  #   * "ca-issuer" is mostly just for development purposes; don't worry about it unless you're developing in minikube or similar.
+  defaultClusterIssuer: letsencrypt
 
 dex:
   create: true

--- a/values.yaml
+++ b/values.yaml
@@ -106,15 +106,13 @@ aws:
 
 certManager:
   create: true
-  fake: false
   replicaCount: 1
   releaseName: md-cert-manager
   namespace: md-cert-manager
   # email: me@example.com
-  # The chart provides 3 ClusterIssuers:
+  # The chart provides 2 ClusterIssuers:
   #   * "letsencrypt" provisions production certs; this is the right choice for production deployment
   #   * "letsencrypt-staging" uses LetsEncrypt's staging server, which is good for testing and has generous rate limits
-  #   * "ca-issuer" is mostly just for development purposes; don't worry about it unless you're developing in minikube or similar.
   defaultClusterIssuer: letsencrypt
 
 dex:


### PR DESCRIPTION
* Remove that old `fake` flag and corresponding CA issuer (I only used it for minikube, and it requires more PKI files that I don't want to deal with, given I was the only user there.)
* Add `letsencrypt-staging` issuer.
* Add `defaultClusterIssuer` config key, defaulted to `letsencrypt` (production)