### PR TITLE
Allow randAlphaNum values to be supplied instead of generated

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -160,7 +160,7 @@ Configures the [`gangway`]() chart to allow users to authenticate via Dex to get
 | `gangway.create` | boolean (optional; default `true`) | Whether to create this HelmRelease |
 | `gangway.namespace` | string (optional) | The namespace for the HelmRelease |
 | `gangway.releaseName` | string (optional) | The release name for the HelmRelease |
-| `gangway.sessionKey` | string (optional, 32 chars) | Random session key. Will be truncated or padded (with random chars) to produce exactly 32 characters. |
+| `gangway.sessionKey` | string (optional, default random) | A 32-character secret session key. |
 
 ## harbor
 
@@ -172,7 +172,7 @@ Configures the [`harbor`](https://github.com/goharbor/harbor-helm) chart.
 | `harbor.namespace` | string (optional) | The namespace for the HelmRelease |
 | `harbor.releaseName` | string (optional) | The release name for the HelmRelease |
 | `harbor.adminPassword` | string (optional; default random) | The initial password for Harbor's `admin` user. |
-| `harbor.secretKey` | string (optional, 16 chars) | Random secret key. Will be truncated or padded (with random chars) to produce exactly 16 characters. |
+| `harbor.secretKey` | string (optional, default random) | A 16-character secret key for encryption. |
 | `harbor.postgres.user` |  |  |
 | `harbor.postgres.password` |  |  |
 | `harbor.persistence.imageChartStorage` |  |  |
@@ -227,7 +227,7 @@ For typical Moondog Engine usage, you should only need to set `oauth.clientSecre
 | `oauth2Proxy.releaseName` | string (optional) | The release name for the HelmRelease |
 | `oauth2Proxy.oauth.clientId` | string | The client id identifying the proxy to Dex. |
 | `oauth2Proxy.oauth.clientSecret` | string | The client secret to authenticate when connecting to Dex. |
-| `oauth2Proxy.oauth.cookieSecret` | string (optional, 32 chars) | Random cookie secret. Will be truncated or padded (with random chars) to produce exactly 32 characters. |
+| `oauth2Proxy.oauth.cookieSecret` | string (optional, default random) | A 32-character secret key for generating cookies. |
 
 ## prometheusOperator
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,7 @@ Configures the [`gangway`]() chart to allow users to authenticate via Dex to get
 | `gangway.create` | boolean (optional; default `true`) | Whether to create this HelmRelease |
 | `gangway.namespace` | string (optional) | The namespace for the HelmRelease |
 | `gangway.releaseName` | string (optional) | The release name for the HelmRelease |
+| `gangway.sessionKey` | string (optional, 32 chars) | Random session key. Will be truncated or padded (with random chars) to produce exactly 32 characters. |
 
 ## harbor
 
@@ -171,6 +172,7 @@ Configures the [`harbor`](https://github.com/goharbor/harbor-helm) chart.
 | `harbor.namespace` | string (optional) | The namespace for the HelmRelease |
 | `harbor.releaseName` | string (optional) | The release name for the HelmRelease |
 | `harbor.adminPassword` | string (optional; default random) | The initial password for Harbor's `admin` user. |
+| `harbor.secretKey` | string (optional, 16 chars) | Random secret key. Will be truncated or padded (with random chars) to produce exactly 16 characters. |
 | `harbor.postgres.user` |  |  |
 | `harbor.postgres.password` |  |  |
 | `harbor.persistence.imageChartStorage` |  |  |
@@ -223,8 +225,9 @@ For typical Moondog Engine usage, you should only need to set `oauth.clientSecre
 | `oauth2Proxy.create` | boolean (optional; default `true`) | Whether to create this HelmRelease |
 | `oauth2Proxy.namespace` | string (optional) | The namespace for the HelmRelease |
 | `oauth2Proxy.releaseName` | string (optional) | The release name for the HelmRelease |
-| `oauth2Proxy.oauth.clientId` |  |  |
-| `oauth2Proxy.oauth.clientSecret` |  |  |
+| `oauth2Proxy.oauth.clientId` | string | The client id identifying the proxy to Dex. |
+| `oauth2Proxy.oauth.clientSecret` | string | The client secret to authenticate when connecting to Dex. |
+| `oauth2Proxy.oauth.cookieSecret` | string (optional, 32 chars) | Random cookie secret. Will be truncated or padded (with random chars) to produce exactly 32 characters. |
 
 ## prometheusOperator
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -45,20 +45,29 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-32 bytes of user-supplied or random characters, base64 encoded
+If input is given, check that it's 32 bytes in length
+If no input is given, generate 32 random bytes
 */}}
-{{- define "moondog.bytes32" -}}
-{{- $param := (dict "length" 32 "input" .input) -}}
-{{- (include "moondog.randomPadded" $param) | b64enc | quote -}}
+{{- define "moondog.random32" -}}
+{{- $value := default (randAlphaNum 32) . }}
+{{- $length := len $value }}
+{{- if eq $length 32 -}}
+{{ $value }}
+{{- else -}}
+{{- fail "Value must be exactly 32 bytes" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Get a string of a certain length
-truncated and/or padded with random chars if necessary
+If input is given, check that it's 16 bytes in length
+If no input is given, generate 16 random bytes
 */}}
-{{- define "moondog.randomPadded" -}}
-{{- $length := .length }}
-{{- $input := default "" .input }}
-{{- $padding := randAlphaNum $length }}
-{{- printf "%s%s" $input $padding | trunc $length -}}
+{{- define "moondog.random16" -}}
+{{- $value := default (randAlphaNum 16) . }}
+{{- $length := len $value }}
+{{- if eq $length 16 -}}
+{{ $value }}
+{{- else -}}
+{{- fail "Value must be exactly 16 bytes" -}}
+{{- end -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -43,3 +43,22 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+32 bytes of user-supplied or random characters, base64 encoded
+*/}}
+{{- define "moondog.bytes32" -}}
+{{- $param := (dict "length" 32 "input" .input) -}}
+{{- (include "moondog.randomPadded" $param) | b64enc | quote -}}
+{{- end -}}
+
+{{/*
+Get a string of a certain length
+truncated and/or padded with random chars if necessary
+*/}}
+{{- define "moondog.randomPadded" -}}
+{{- $length := .length }}
+{{- $input := default "" .input }}
+{{- $padding := randAlphaNum $length }}
+{{- printf "%s%s" $input $padding | trunc $length -}}
+{{- end -}}

--- a/templates/gangway.yaml
+++ b/templates/gangway.yaml
@@ -39,7 +39,7 @@ spec:
       clusterName: {{ .Values.clusterName }}
       clientID: {{ .Values.dex.oauth.clientId | quote }}
       clientSecret: {{ .Values.dex.oauth.clientSecret | quote }}
-      sessionKey: {{ include "moondog.bytes32" (dict "input" .Values.gangway.sessionKey) }}
+      sessionKey: {{ include "moondog.random32" .Values.gangway.sessionKey | b64enc | quote }}
       authorizeURL: https://dex.{{ .Values.domainSuffix }}/auth
       tokenURL: https://dex.{{ .Values.domainSuffix }}/token
       audience: https://dex.{{ .Values.domainSuffix }}/userinfo

--- a/templates/gangway.yaml
+++ b/templates/gangway.yaml
@@ -39,7 +39,7 @@ spec:
       clusterName: {{ .Values.clusterName }}
       clientID: {{ .Values.dex.oauth.clientId | quote }}
       clientSecret: {{ .Values.dex.oauth.clientSecret | quote }}
-      sessionKey: {{ randAlphaNum 32 | b64enc | quote }}
+      sessionKey: {{ include "moondog.bytes32" (dict "input" .Values.gangway.sessionKey) }}
       authorizeURL: https://dex.{{ .Values.domainSuffix }}/auth
       tokenURL: https://dex.{{ .Values.domainSuffix }}/token
       audience: https://dex.{{ .Values.domainSuffix }}/userinfo

--- a/templates/harbor.yaml
+++ b/templates/harbor.yaml
@@ -19,7 +19,7 @@ spec:
     version: 1.3.1
   values:
     harborAdminPassword: {{ default (randAlphaNum 32) .Values.harbor.adminPassword | quote }}
-    secretKey: {{ include "moondog.randomPadded" (dict "length" 16 "input" .Values.harbor.secretKey) | quote }}
+    secretKey: {{ include "moondog.random16" .Values.harbor.secretKey | quote }}
     expose:
       ingress:
         hosts:

--- a/templates/harbor.yaml
+++ b/templates/harbor.yaml
@@ -19,7 +19,7 @@ spec:
     version: 1.3.1
   values:
     harborAdminPassword: {{ default (randAlphaNum 32) .Values.harbor.adminPassword | quote }}
-    secretKey: {{ randAlphaNum 16 | quote }}
+    secretKey: {{ include "moondog.randomPadded" (dict "length" 16 "input" .Values.harbor.secretKey) | quote }}
     expose:
       ingress:
         hosts:

--- a/templates/oauth2-proxy.yaml
+++ b/templates/oauth2-proxy.yaml
@@ -20,7 +20,7 @@ spec:
     config:
       clientID: {{ .Values.oauth2Proxy.oauth.clientId | quote }}
       clientSecret: {{ .Values.oauth2Proxy.oauth.clientSecret | quote }}
-      cookieSecret: {{ randAlphaNum 32 | b64enc | quote }}
+      cookieSecret: {{ include "moondog.bytes32" (dict "input" .Values.oauth2Proxy.oauth.cookieSecret) }}
     extraArgs:
       cookie-domain: .{{ .Values.domainSuffix }}
       whitelist-domain: .{{ .Values.domainSuffix }}

--- a/templates/oauth2-proxy.yaml
+++ b/templates/oauth2-proxy.yaml
@@ -20,7 +20,7 @@ spec:
     config:
       clientID: {{ .Values.oauth2Proxy.oauth.clientId | quote }}
       clientSecret: {{ .Values.oauth2Proxy.oauth.clientSecret | quote }}
-      cookieSecret: {{ include "moondog.bytes32" (dict "input" .Values.oauth2Proxy.oauth.cookieSecret) }}
+      cookieSecret: {{ include "moondog.random32" .Values.oauth2Proxy.oauth.cookieSecret | b64enc | quote }}
     extraArgs:
       cookie-domain: .{{ .Values.domainSuffix }}
       whitelist-domain: .{{ .Values.domainSuffix }}


### PR DESCRIPTION
Connects to #23 

Updates 3 places where `randAlphaNum` was used so that values can be supplied to keep things deterministic. Based on a little bit of research, it seems like the length of all 3 is required to be fixed (16 characters for Harbor,  32 bytes base64 encoded for Gangway and OAuth2 Proxy), so they all use similar logic.

~~This implementation pads or truncates if the user input isn't exactly the right length. I also considered just throwing out the user input if it's not the right length, as well...~~