### PR TITLE
Installer: remove compiled templates from previous runs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,8 @@ fi
 
 ### GENERATE THE TEMPLATE OUTPUTS
 
-# create tmp directory if it does not exist
-mkdir -p tmp
+# create tmp directory if it does not exist, and clear out files from previous runs
+mkdir -p tmp && rm -rf tmp/*
 
 # template out the chart
 helm template . \


### PR DESCRIPTION
Connects to #30 

I think this is safe and sufficient, but stop me if I'm missing something