### PR TITLE
Update Harbor db username to 'postgres' to fix replication

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -166,8 +166,7 @@ Configures the [`harbor`](https://github.com/goharbor/harbor-helm) chart.
 | `harbor.releaseName` | string (optional) | The release name for the HelmRelease |
 | `harbor.adminPassword` | string (optional; default random) | The initial password for Harbor's `admin` user. |
 | `harbor.secretKey` | string (optional, default random) | A 16-character secret key for encryption. |
-| `harbor.postgres.user` |  |  |
-| `harbor.postgres.password` |  |  |
+| `harbor.postgres.password` | string | Password for the `postgres` user in the Harbor database. |
 | `harbor.persistence.imageChartStorage` |  |  |
 | `harbor.dbBackups.enabled` | boolean (optional; default `true`) | Whether to enable DB backups. `true` requires the other backup options also. |
 | `harbor.dbBackups.bucketName` | string (optional) | Name of an S3 bucket to use for database backups. |

--- a/templates/harbor-kubedb.yaml
+++ b/templates/harbor-kubedb.yaml
@@ -72,7 +72,7 @@ metadata:
 type: Opaque
 data:
   POSTGRES_PASSWORD: {{ .Values.harbor.postgres.password | b64enc | quote }}
-  POSTGRES_USER: {{ .Values.harbor.postgres.user | b64enc | quote }}
+  POSTGRES_USER: {{ "postgres" | b64enc | quote }}
 
 {{- if $backupsEnabled }}
 ---

--- a/templates/harbor.yaml
+++ b/templates/harbor.yaml
@@ -43,7 +43,7 @@ spec:
       type: external
       external:
         host: harbor-pg
-        username: {{ .Values.harbor.postgres.user }}
+        username: "postgres"
         password: {{ .Values.harbor.postgres.password | quote }}
     redis:
       type: external

--- a/values.yaml
+++ b/values.yaml
@@ -154,8 +154,7 @@ harbor:
   releaseName: md-harbor
   namespace: md-harbor
   # adminPassword: "your admin password"
-  postgres:
-    user: md_harbor
+  postgres: {}
   dbBackups:
     enabled: true
     # bucketName: S3_BUCKET_NAME


### PR DESCRIPTION
Connects to #35 

As suspected, changing the postgres username to `"postgres"` makes the auth errors go away in the primary postgres pod and the secondary shows what we'd expect instead of just repeated cxn attempts.

![Screen Shot 2020-05-12 at 11 44 42 AM](https://user-images.githubusercontent.com/802805/81722304-ca3f7780-9446-11ea-87be-e740657e6e47.png)
